### PR TITLE
feat: add dark mode with system preference detection

### DIFF
--- a/coding-agents.html
+++ b/coding-agents.html
@@ -904,6 +904,33 @@
                 display: none;
             }
         }
+
+        body.dark-mode .comparison-table tbody tr {
+            background: rgba(30, 33, 41, 0.85);
+        }
+
+        body.dark-mode .comparison-table tbody tr:nth-child(even) {
+            background: rgba(24, 27, 35, 0.85);
+        }
+
+        body.dark-mode .comparison-table tbody tr:hover {
+            background: rgba(45, 212, 191, 0.06);
+        }
+
+        body.dark-mode #agentsTable td:first-child,
+        body.dark-mode #plansTable td:first-child {
+            background: linear-gradient(90deg, rgba(30, 33, 41, 0.96) 0%, rgba(30, 33, 41, 0.96) 86%, rgba(30, 33, 41, 0) 100%);
+        }
+
+        body.dark-mode #agentsTable tbody tr:nth-child(even) td:first-child,
+        body.dark-mode #plansTable tbody tr:nth-child(even) td:first-child {
+            background: linear-gradient(90deg, rgba(24, 27, 35, 0.96) 0%, rgba(24, 27, 35, 0.96) 86%, rgba(24, 27, 35, 0) 100%);
+        }
+
+        body.dark-mode #agentsTable tbody tr:hover td:first-child,
+        body.dark-mode #plansTable tbody tr:hover td:first-child {
+            background: linear-gradient(90deg, rgba(28, 38, 38, 0.96) 0%, rgba(28, 38, 38, 0.96) 86%, rgba(28, 38, 38, 0) 100%);
+        }
     </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -2162,6 +2162,213 @@
                 display: none;
             }
         }
+
+        body.dark-mode .table-wrapper {
+            background: rgba(24, 27, 35, 0.8);
+            border-color: rgba(255, 255, 255, 0.06);
+        }
+
+        body.dark-mode th,
+        body.dark-mode th.sticky-first,
+        body.dark-mode th.sticky-second {
+            background: rgba(12, 16, 24, 0.96);
+        }
+
+        body.dark-mode th:hover {
+            background: rgba(12, 16, 24, 0.96);
+        }
+
+        body.dark-mode td {
+            background: rgba(30, 33, 41, 0.88);
+        }
+
+        body.dark-mode tbody tr:nth-child(even) td {
+            background: rgba(24, 27, 35, 0.85);
+        }
+
+        body.dark-mode tbody tr:hover td {
+            background: rgba(45, 212, 191, 0.06);
+        }
+
+        body.dark-mode td.sticky-first,
+        body.dark-mode td.sticky-second {
+            background: linear-gradient(90deg, rgba(30, 33, 41, 0.96) 0%, rgba(30, 33, 41, 0.96) 86%, rgba(30, 33, 41, 0) 100%);
+        }
+
+        body.dark-mode tbody tr:nth-child(even) td.sticky-first,
+        body.dark-mode tbody tr:nth-child(even) td.sticky-second {
+            background: linear-gradient(90deg, rgba(24, 27, 35, 0.96) 0%, rgba(24, 27, 35, 0.96) 86%, rgba(24, 27, 35, 0) 100%);
+        }
+
+        body.dark-mode tbody tr:hover td.sticky-first,
+        body.dark-mode tbody tr:hover td.sticky-second {
+            background: linear-gradient(90deg, rgba(28, 38, 38, 0.96) 0%, rgba(28, 38, 38, 0.96) 86%, rgba(28, 38, 38, 0) 100%);
+        }
+
+        body.dark-mode .recommendation-card {
+            background: rgba(24, 27, 35, 0.8);
+            border-color: rgba(255, 255, 255, 0.06);
+        }
+
+        body.dark-mode .recommendation-card:hover {
+            border-color: rgba(45, 212, 191, 0.2);
+        }
+
+        body.dark-mode .recommendation-name-link:hover {
+            color: var(--accent-primary);
+        }
+
+        body.dark-mode .rating-guide {
+            background: rgba(24, 27, 35, 0.7);
+            border-color: rgba(255, 255, 255, 0.06);
+        }
+
+        body.dark-mode .filter-btn,
+        body.dark-mode .reset-btn,
+        body.dark-mode .checkbox-label,
+        body.dark-mode .stats-bar {
+            background: rgba(30, 33, 41, 0.72);
+            border-color: rgba(255, 255, 255, 0.08);
+        }
+
+        body.dark-mode .filter-btn:hover,
+        body.dark-mode .checkbox-label:hover {
+            background: rgba(45, 212, 191, 0.08);
+            border-color: rgba(45, 212, 191, 0.2);
+        }
+
+        body.dark-mode .filter-btn.active {
+            background: linear-gradient(135deg, rgba(45, 212, 191, 0.12), rgba(245, 158, 11, 0.12));
+            border-color: rgba(45, 212, 191, 0.2);
+            color: var(--accent-primary);
+        }
+
+        body.dark-mode .radio-label,
+        body.dark-mode .account-card,
+        body.dark-mode .contact-section {
+            background: rgba(30, 33, 41, 0.7);
+            border-color: rgba(255, 255, 255, 0.06);
+        }
+
+        body.dark-mode .radio-label:hover,
+        body.dark-mode .dropdown-btn.secondary:hover {
+            background: rgba(45, 212, 191, 0.08);
+            border-color: rgba(45, 212, 191, 0.18);
+        }
+
+        body.dark-mode .dropdown-menu {
+            background: rgba(24, 27, 35, 0.96);
+        }
+
+        body.dark-mode .checkbox-label:has(input:checked) {
+            background: rgba(45, 212, 191, 0.12);
+            border-color: rgba(45, 212, 191, 0.2);
+        }
+
+        body.dark-mode .reset-btn:hover {
+            background: rgba(245, 158, 11, 0.08);
+            border-color: rgba(245, 158, 11, 0.2);
+            color: var(--accent-secondary);
+        }
+
+        body.dark-mode .hero-summary-card--reading {
+            background: linear-gradient(165deg, rgba(45, 212, 191, 0.06), rgba(24, 27, 35, 0.85));
+        }
+
+        body.dark-mode .hero-summary-card--reading .hero-summary-kicker {
+            color: #2dd4bf;
+            background: rgba(45, 212, 191, 0.12);
+        }
+
+        body.dark-mode .hero-summary-card--guide {
+            background: linear-gradient(165deg, rgba(245, 158, 11, 0.06), rgba(24, 27, 35, 0.85));
+            border-color: rgba(245, 158, 11, 0.12);
+        }
+
+        body.dark-mode .hero-summary-card--guide .hero-summary-kicker {
+            color: #f59e0b;
+            background: rgba(245, 158, 11, 0.12);
+        }
+
+        body.dark-mode .preset-tag-chip {
+            background: linear-gradient(135deg, rgba(30, 33, 41, 0.92), rgba(30, 33, 41, 0.92));
+            border-color: rgba(255, 255, 255, 0.08);
+            color: var(--text-secondary);
+        }
+
+        body.dark-mode .preset-tag-chip:hover {
+            border-color: rgba(45, 212, 191, 0.28);
+            color: var(--text-primary);
+        }
+
+        body.dark-mode .preset-tag-chip.active {
+            background: linear-gradient(135deg, #173753, #0f766e);
+            color: white;
+        }
+
+        body.dark-mode .feedback-float-trigger {
+            background: rgba(24, 27, 35, 0.94);
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        body.dark-mode .feedback-float-trigger:hover {
+            background: rgba(30, 33, 41, 0.96);
+            border-color: rgba(45, 212, 191, 0.28);
+        }
+
+        body.dark-mode .feedback-float-trigger-icon {
+            background: rgba(45, 212, 191, 0.12);
+            color: #2dd4bf;
+        }
+
+        body.dark-mode .feedback-float-panel {
+            background: rgba(24, 27, 35, 0.96);
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        body.dark-mode .feedback-float-action-link {
+            background: rgba(30, 33, 41, 0.78);
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        body.dark-mode .feedback-float-action-link:hover {
+            border-color: rgba(45, 212, 191, 0.24);
+            background: rgba(45, 212, 191, 0.08);
+        }
+
+        body.dark-mode .feedback-float-feishu {
+            border-top-color: rgba(255, 255, 255, 0.08);
+        }
+
+        body.dark-mode .section-title::after {
+            background: linear-gradient(90deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0));
+        }
+
+        body.dark-mode .hero-summary-lede-media a {
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        body.dark-mode .page-tab:hover {
+            background: rgba(45, 212, 191, 0.08);
+        }
+
+        body.dark-mode .settings-btn:hover,
+        body.dark-mode .settings-btn.active {
+            background: rgba(30, 33, 41, 0.78);
+            border-color: rgba(255, 255, 255, 0.1);
+        }
+
+        body.dark-mode .toggle-slider {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        body.dark-mode .toggle-switch input:checked + .toggle-slider {
+            background: var(--accent-primary);
+        }
+
+        body.dark-mode .toggle-slider::before {
+            background: #e0e0e0;
+        }
     </style>
 </head>
 <body>

--- a/scripts/shared.js
+++ b/scripts/shared.js
@@ -160,12 +160,59 @@ function renderPageNav(target, options = {}) {
                             <span class="toggle-slider"></span>
                         </label>
                     </div>
+                    <div class="settings-toggle-row" style="margin-top:10px">
+                        <label for="darkModeToggle">深色模式</label>
+                        <label class="toggle-switch">
+                            <input type="checkbox" id="darkModeToggle">
+                            <span class="toggle-slider"></span>
+                        </label>
+                    </div>
                 </div>
             </div>
         </div>
     `;
     return true;
 }
+
+// 深色模式设置
+(function () {
+    function initDarkMode() {
+        const toggle = document.getElementById('darkModeToggle');
+        if (!toggle) return;
+
+        const darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const saved = localStorage.getItem('darkMode');
+
+        function applyDarkMode(on) {
+            document.body.classList.toggle('dark-mode', on);
+            toggle.checked = on;
+        }
+
+        if (saved !== null) {
+            applyDarkMode(saved === '1');
+        } else {
+            applyDarkMode(darkQuery.matches);
+        }
+
+        toggle.addEventListener('change', function () {
+            applyDarkMode(toggle.checked);
+            localStorage.setItem('darkMode', toggle.checked ? '1' : '0');
+        });
+
+        darkQuery.addEventListener('change', function (e) {
+            if (localStorage.getItem('darkMode') === null) {
+                applyDarkMode(e.matches);
+            }
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initDarkMode, { once: true });
+        return;
+    }
+
+    initDarkMode();
+})();
 
 // 超宽屏设置
 (function () {

--- a/styles/plan-usage.css
+++ b/styles/plan-usage.css
@@ -8,6 +8,11 @@
     backdrop-filter: blur(8px);
 }
 
+body.dark-mode .plan-usage-panel {
+    background: rgba(24, 27, 35, 0.8);
+    border-color: rgba(255, 255, 255, 0.06);
+}
+
 .plan-usage-panel[hidden] {
     display: none !important;
 }
@@ -39,6 +44,11 @@
     text-transform: uppercase;
 }
 
+body.dark-mode .plan-usage-kicker {
+    color: #8dd0e6;
+    background: rgba(45, 212, 191, 0.1);
+}
+
 .plan-usage-title {
     margin: 12px 0 8px;
     font-size: clamp(24px, 3vw, 32px);
@@ -52,6 +62,10 @@
     font-size: 14px;
     line-height: 1.75;
     max-width: 860px;
+}
+
+body.dark-mode .plan-usage-description {
+    color: var(--text-secondary);
 }
 
 .plan-usage-meta {
@@ -74,6 +88,11 @@
     font-size: 12px;
     font-weight: 700;
     box-shadow: 0 10px 20px rgba(23, 32, 51, 0.05);
+}
+
+body.dark-mode .plan-usage-chip {
+    background: rgba(30, 33, 41, 0.72);
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 .plan-usage-chip strong {
@@ -107,6 +126,11 @@
     box-shadow: 0 10px 20px rgba(23, 32, 51, 0.05);
 }
 
+body.dark-mode .plan-usage-panel .segmented-control {
+    background: rgba(30, 33, 41, 0.72);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
 .plan-usage-panel .segment-btn {
     min-width: 82px;
     min-height: 42px;
@@ -135,6 +159,10 @@
     color: #f7fffd;
 }
 
+body.dark-mode .plan-usage-panel .segment-btn.active {
+    background: linear-gradient(135deg, #0a1628, #0d5c56);
+}
+
 .plan-usage-panel .segment-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
@@ -156,10 +184,21 @@
     padding: 14px 18px;
 }
 
+body.dark-mode .plan-usage-state {
+    background: rgba(30, 33, 41, 0.52);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
 .plan-usage-state.is-error {
     color: #9f1239;
     border-color: rgba(239, 68, 68, 0.2);
     background: rgba(255, 236, 236, 0.72);
+}
+
+body.dark-mode .plan-usage-state.is-error {
+    color: #fca5a5;
+    border-color: rgba(239, 68, 68, 0.25);
+    background: rgba(50, 20, 20, 0.72);
 }
 
 .plan-usage-chart {
@@ -169,6 +208,11 @@
     border-radius: 22px;
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(248, 242, 231, 0.7));
     border: 1px solid rgba(23, 32, 51, 0.08);
+}
+
+body.dark-mode .plan-usage-chart {
+    background: linear-gradient(180deg, rgba(24, 27, 35, 0.5), rgba(30, 33, 41, 0.7));
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 .plan-usage-chart[hidden] {
@@ -193,6 +237,11 @@
     border: 1px solid rgba(23, 32, 51, 0.08);
     background: rgba(255, 255, 255, 0.28);
     min-width: 0;
+}
+
+body.dark-mode .plan-usage-chart-block {
+    background: rgba(30, 33, 41, 0.28);
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 .plan-usage-chart-header {

--- a/styles/shared.css
+++ b/styles/shared.css
@@ -28,6 +28,25 @@
     --radius-md: 8px;
     --radius-lg: 12px;
     --radius-xl: 16px;
+    --color-scheme: light;
+}
+
+body.dark-mode {
+    --bg-primary: #111318;
+    --bg-secondary: rgba(24, 27, 35, 0.92);
+    --bg-tertiary: #1e2129;
+    --text-primary: #e4e6eb;
+    --text-secondary: #a0a4af;
+    --text-tertiary: #6b7080;
+    --border-color: rgba(255, 255, 255, 0.1);
+    --border-light: rgba(255, 255, 255, 0.06);
+    --accent-primary: #2dd4bf;
+    --accent-secondary: #f59e0b;
+    --shadow-sm: 0 6px 18px rgba(0, 0, 0, 0.25);
+    --shadow-md: 0 14px 36px rgba(0, 0, 0, 0.3);
+    --shadow-lg: 0 20px 48px rgba(0, 0, 0, 0.35);
+    --shadow-xl: 0 28px 64px rgba(0, 0, 0, 0.4);
+    --color-scheme: dark;
 }
 
 body {
@@ -42,6 +61,13 @@ body {
     padding: 28px 34px 64px;
     font-size: 14px;
     overflow-x: hidden;
+}
+
+body.dark-mode {
+    background:
+        radial-gradient(circle at top left, rgba(45, 212, 191, 0.06), transparent 26%),
+        radial-gradient(circle at top right, rgba(245, 158, 11, 0.06), transparent 24%),
+        linear-gradient(180deg, #111318 0%, #161a22 42%, #111318 100%);
 }
 
 .container {
@@ -73,6 +99,12 @@ body {
     top: 14px;
     z-index: 40;
     overflow: visible;
+}
+
+body.dark-mode .page-nav-cluster {
+    background: rgba(24, 27, 35, 0.88);
+    border-color: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.3);
 }
 
 .page-nav {
@@ -117,6 +149,11 @@ body {
     box-shadow: 0 12px 24px rgba(28, 53, 82, 0.18);
 }
 
+body.dark-mode .page-tab.active {
+    background: linear-gradient(135deg, #0a1628 0%, #0d5c56 100%);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+}
+
 /* ── Header ── */
 .header {
     margin-bottom: 28px;
@@ -128,6 +165,11 @@ body {
     background: linear-gradient(135deg, rgba(255, 252, 246, 0.96) 0%, rgba(255, 248, 238, 0.84) 56%, rgba(239, 246, 244, 0.92) 100%);
     box-shadow: var(--shadow-lg);
     overflow: hidden;
+}
+
+body.dark-mode .header {
+    background: linear-gradient(135deg, rgba(24, 27, 35, 0.96) 0%, rgba(20, 24, 32, 0.92) 56%, rgba(18, 28, 28, 0.92) 100%);
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 .header::before,
@@ -146,12 +188,20 @@ body {
     background: radial-gradient(circle, rgba(15, 118, 110, 0.18), rgba(15, 118, 110, 0));
 }
 
+body.dark-mode .header::before {
+    background: radial-gradient(circle, rgba(45, 212, 191, 0.12), rgba(45, 212, 191, 0));
+}
+
 .header::after {
     width: 320px;
     height: 320px;
     left: -160px;
     bottom: -180px;
     background: radial-gradient(circle, rgba(198, 107, 26, 0.16), rgba(198, 107, 26, 0));
+}
+
+body.dark-mode .header::after {
+    background: radial-gradient(circle, rgba(245, 158, 11, 0.1), rgba(245, 158, 11, 0));
 }
 
 .header > * {
@@ -184,6 +234,11 @@ body {
     transform: translateY(-1px);
 }
 
+body.dark-mode .github-link {
+    background: rgba(30, 33, 41, 0.88);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
 .header h1 {
     max-width: calc(100% - 140px);
     font-size: clamp(40px, 6vw, 68px);
@@ -208,6 +263,11 @@ body {
     background: rgba(24, 52, 79, 0.08);
 }
 
+body.dark-mode .update-date {
+    color: #8dd0e6;
+    background: rgba(45, 212, 191, 0.1);
+}
+
 .header .subtitle {
     width: 100%;
     max-width: 100%;
@@ -216,6 +276,10 @@ body {
     margin-bottom: 18px;
     font-weight: 500;
     line-height: 1.72;
+}
+
+body.dark-mode .header .subtitle {
+    color: var(--text-secondary);
 }
 
 .header .models,
@@ -230,6 +294,12 @@ body {
     color: var(--text-secondary);
     line-height: 1.75;
     box-shadow: 0 10px 20px rgba(23, 32, 51, 0.05);
+}
+
+body.dark-mode .header .models,
+body.dark-mode .header-info {
+    background: rgba(30, 33, 41, 0.7);
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 /* ── 超宽屏模式 ── */
@@ -283,6 +353,10 @@ body {
     width: 230px;
     box-shadow: var(--shadow-xl);
     z-index: 2000;
+}
+
+body.dark-mode .settings-panel {
+    background: rgba(24, 27, 35, 0.95);
 }
 
 .settings-panel-title {
@@ -362,6 +436,11 @@ body {
     backdrop-filter: blur(8px);
 }
 
+body.dark-mode .notes-section {
+    background: rgba(24, 27, 35, 0.8);
+    border-color: rgba(255, 255, 255, 0.06);
+}
+
 .notes-section h3 {
     font-size: 20px;
     font-weight: 800;
@@ -400,6 +479,11 @@ body {
     background: rgba(255, 251, 245, 0.84);
     box-shadow: var(--shadow-md);
     backdrop-filter: blur(8px);
+}
+
+body.dark-mode .updates-section {
+    background: rgba(24, 27, 35, 0.8);
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 .updates-section h3 {
@@ -471,12 +555,25 @@ body {
     backdrop-filter: blur(8px);
 }
 
+body.dark-mode .hero-summary-card {
+    background: rgba(24, 27, 35, 0.8);
+    border-color: rgba(255, 255, 255, 0.06);
+}
+
 .hero-summary-card--accent {
     background: linear-gradient(180deg, rgba(15, 118, 110, 0.09), rgba(255, 255, 255, 0.88));
 }
 
+body.dark-mode .hero-summary-card--accent {
+    background: linear-gradient(180deg, rgba(45, 212, 191, 0.08), rgba(24, 27, 35, 0.6));
+}
+
 .hero-summary-card--warm {
     background: linear-gradient(180deg, rgba(198, 107, 26, 0.09), rgba(255, 255, 255, 0.88));
+}
+
+body.dark-mode .hero-summary-card--warm {
+    background: linear-gradient(180deg, rgba(245, 158, 11, 0.08), rgba(24, 27, 35, 0.6));
 }
 
 .hero-summary-card--community {
@@ -485,6 +582,11 @@ body {
     overflow: hidden;
     border-color: rgba(15, 118, 110, 0.18);
     background: linear-gradient(135deg, rgba(15, 118, 110, 0.12) 0%, rgba(255, 251, 245, 0.96) 48%, rgba(198, 107, 26, 0.1) 100%);
+}
+
+body.dark-mode .hero-summary-card--community {
+    background: linear-gradient(135deg, rgba(45, 212, 191, 0.08) 0%, rgba(24, 27, 35, 0.9) 48%, rgba(245, 158, 11, 0.06) 100%);
+    border-color: rgba(45, 212, 191, 0.15);
 }
 
 .hero-summary-card--community::after {
@@ -586,6 +688,11 @@ body {
     box-shadow: 0 10px 20px rgba(23, 32, 51, 0.06);
 }
 
+body.dark-mode .community-hub-btn--secondary {
+    background: rgba(30, 33, 41, 0.82);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
 .community-hub-btn--secondary:hover {
     border-color: rgba(15, 118, 110, 0.24);
 }
@@ -594,6 +701,12 @@ body {
     color: #18344f;
     background: rgba(24, 52, 79, 0.08);
     border: 1px solid rgba(24, 52, 79, 0.1);
+}
+
+body.dark-mode .community-hub-badge {
+    color: var(--text-secondary);
+    background: rgba(45, 212, 191, 0.08);
+    border-color: rgba(45, 212, 191, 0.1);
 }
 
 .community-hub-footnote {
@@ -613,6 +726,11 @@ body {
     border: 1px solid rgba(23, 32, 51, 0.08);
     background: rgba(255, 255, 255, 0.72);
     box-shadow: 0 12px 22px rgba(23, 32, 51, 0.06);
+}
+
+body.dark-mode .community-hub-qr {
+    background: rgba(30, 33, 41, 0.7);
+    border-color: rgba(255, 255, 255, 0.06);
 }
 
 .community-hub-qr img {
@@ -704,6 +822,11 @@ body {
     backdrop-filter: blur(8px);
 }
 
+body.dark-mode .surface-panel {
+    background: rgba(24, 27, 35, 0.8);
+    border-color: rgba(255, 255, 255, 0.06);
+}
+
 .surface-panel--padded {
     padding: 24px 28px;
 }
@@ -719,10 +842,19 @@ body {
     box-shadow: 0 10px 20px rgba(23, 32, 51, 0.05);
 }
 
+body.dark-mode .surface-control {
+    background: rgba(30, 33, 41, 0.72);
+    border-color: rgba(255, 255, 255, 0.06);
+}
+
 .surface-popover {
     background: rgba(255, 251, 245, 0.96);
     border-radius: 18px;
     box-shadow: var(--shadow-lg);
+}
+
+body.dark-mode .surface-popover {
+    background: rgba(24, 27, 35, 0.96);
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
为 codingplan 添加深色模式支持。

**变更内容：**
- styles/shared.css — body.dark-mode CSS 变量覆盖及 UI 元件暗色适配
- styles/plan-usage.css — 用量面板、图表区块暗色适配
- scripts/shared.js — 设置面板新增深色模式开关，自动跟随系统主题
- index.html — 表格、筛选、推荐卡片、反馈浮窗暗色适配
- coding-agents.html — 表格行暗色适配

**行为：**
- 首次访问自动跟随系统 prefers-color-scheme
- 手动切换后记住用户选择（localStorage）
- 设置面板内与超宽屏开关并列